### PR TITLE
Semaphore API

### DIFF
--- a/FreeRTOS/include/FreeRTOS.h
+++ b/FreeRTOS/include/FreeRTOS.h
@@ -56,6 +56,7 @@
 /* *INDENT-ON* */
 
 #include <rtthread.h>
+#include <rthw.h>
 
 /* Application specific configuration options. */
 #include "FreeRTOSConfig.h"

--- a/FreeRTOS/include/queue.h
+++ b/FreeRTOS/include/queue.h
@@ -171,6 +171,11 @@ void vQueueDelete( QueueHandle_t xQueue );
 QueueHandle_t xQueueCreateMutex( const uint8_t ucQueueType );
 QueueHandle_t xQueueCreateMutexStatic( const uint8_t ucQueueType,
                                        StaticQueue_t * pxStaticQueue );
+QueueHandle_t xQueueCreateCountingSemaphore( const UBaseType_t uxMaxCount,
+                                             const UBaseType_t uxInitialCount );
+QueueHandle_t xQueueCreateCountingSemaphoreStatic( const UBaseType_t uxMaxCount,
+                                                   const UBaseType_t uxInitialCount,
+                                                   StaticQueue_t * pxStaticQueue );
 BaseType_t xQueueSemaphoreTake( QueueHandle_t xQueue,
                                 TickType_t xTicksToWait );
 

--- a/FreeRTOS/include/semphr.h
+++ b/FreeRTOS/include/semphr.h
@@ -37,6 +37,266 @@
 
 typedef QueueHandle_t SemaphoreHandle_t;
 
+#define semBINARY_SEMAPHORE_QUEUE_LENGTH    ( ( uint8_t ) 1U )
+#define semSEMAPHORE_QUEUE_ITEM_LENGTH      ( ( uint8_t ) 0U )
+#define semGIVE_BLOCK_TIME                  ( ( TickType_t ) 0U )
+
+
+/**
+ * semphr. h
+ * @code{c}
+ * vSemaphoreCreateBinary( SemaphoreHandle_t xSemaphore );
+ * @endcode
+ *
+ * In many usage scenarios it is faster and more memory efficient to use a
+ * direct to task notification in place of a binary semaphore!
+ * https://www.FreeRTOS.org/RTOS-task-notifications.html
+ *
+ * This old vSemaphoreCreateBinary() macro is now deprecated in favour of the
+ * xSemaphoreCreateBinary() function.  Note that binary semaphores created using
+ * the vSemaphoreCreateBinary() macro are created in a state such that the
+ * first call to 'take' the semaphore would pass, whereas binary semaphores
+ * created using xSemaphoreCreateBinary() are created in a state such that the
+ * the semaphore must first be 'given' before it can be 'taken'.
+ *
+ * <i>Macro</i> that implements a semaphore by using the existing queue mechanism.
+ * The queue length is 1 as this is a binary semaphore.  The data size is 0
+ * as we don't want to actually store any data - we just want to know if the
+ * queue is empty or full.
+ *
+ * This type of semaphore can be used for pure synchronisation between tasks or
+ * between an interrupt and a task.  The semaphore need not be given back once
+ * obtained, so one task/interrupt can continuously 'give' the semaphore while
+ * another continuously 'takes' the semaphore.  For this reason this type of
+ * semaphore does not use a priority inheritance mechanism.  For an alternative
+ * that does use priority inheritance see xSemaphoreCreateMutex().
+ *
+ * @param xSemaphore Handle to the created semaphore.  Should be of type SemaphoreHandle_t.
+ *
+ * Example usage:
+ * @code{c}
+ * SemaphoreHandle_t xSemaphore = NULL;
+ *
+ * void vATask( void * pvParameters )
+ * {
+ *  // Semaphore cannot be used before a call to vSemaphoreCreateBinary ().
+ *  // This is a macro so pass the variable in directly.
+ *  vSemaphoreCreateBinary( xSemaphore );
+ *
+ *  if( xSemaphore != NULL )
+ *  {
+ *      // The semaphore was created successfully.
+ *      // The semaphore can now be used.
+ *  }
+ * }
+ * @endcode
+ * \defgroup vSemaphoreCreateBinary vSemaphoreCreateBinary
+ * \ingroup Semaphores
+ */
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+    #define vSemaphoreCreateBinary( xSemaphore )                                                                                     \
+    {                                                                                                                                \
+        ( xSemaphore ) = xQueueGenericCreate( ( UBaseType_t ) 1, semSEMAPHORE_QUEUE_ITEM_LENGTH, queueQUEUE_TYPE_BINARY_SEMAPHORE ); \
+        if( ( xSemaphore ) != NULL )                                                                                                 \
+        {                                                                                                                            \
+            ( void ) xSemaphoreGive( ( xSemaphore ) );                                                                               \
+        }                                                                                                                            \
+    }
+#endif
+
+/**
+ * semphr. h
+ * @code{c}
+ * SemaphoreHandle_t xSemaphoreCreateBinary( void );
+ * @endcode
+ *
+ * Creates a new binary semaphore instance, and returns a handle by which the
+ * new semaphore can be referenced.
+ *
+ * In many usage scenarios it is faster and more memory efficient to use a
+ * direct to task notification in place of a binary semaphore!
+ * https://www.FreeRTOS.org/RTOS-task-notifications.html
+ *
+ * Internally, within the FreeRTOS implementation, binary semaphores use a block
+ * of memory, in which the semaphore structure is stored.  If a binary semaphore
+ * is created using xSemaphoreCreateBinary() then the required memory is
+ * automatically dynamically allocated inside the xSemaphoreCreateBinary()
+ * function.  (see https://www.FreeRTOS.org/a00111.html).  If a binary semaphore
+ * is created using xSemaphoreCreateBinaryStatic() then the application writer
+ * must provide the memory.  xSemaphoreCreateBinaryStatic() therefore allows a
+ * binary semaphore to be created without using any dynamic memory allocation.
+ *
+ * The old vSemaphoreCreateBinary() macro is now deprecated in favour of this
+ * xSemaphoreCreateBinary() function.  Note that binary semaphores created using
+ * the vSemaphoreCreateBinary() macro are created in a state such that the
+ * first call to 'take' the semaphore would pass, whereas binary semaphores
+ * created using xSemaphoreCreateBinary() are created in a state such that the
+ * the semaphore must first be 'given' before it can be 'taken'.
+ *
+ * This type of semaphore can be used for pure synchronisation between tasks or
+ * between an interrupt and a task.  The semaphore need not be given back once
+ * obtained, so one task/interrupt can continuously 'give' the semaphore while
+ * another continuously 'takes' the semaphore.  For this reason this type of
+ * semaphore does not use a priority inheritance mechanism.  For an alternative
+ * that does use priority inheritance see xSemaphoreCreateMutex().
+ *
+ * @return Handle to the created semaphore, or NULL if the memory required to
+ * hold the semaphore's data structures could not be allocated.
+ *
+ * Example usage:
+ * @code{c}
+ * SemaphoreHandle_t xSemaphore = NULL;
+ *
+ * void vATask( void * pvParameters )
+ * {
+ *  // Semaphore cannot be used before a call to xSemaphoreCreateBinary().
+ *  // This is a macro so pass the variable in directly.
+ *  xSemaphore = xSemaphoreCreateBinary();
+ *
+ *  if( xSemaphore != NULL )
+ *  {
+ *      // The semaphore was created successfully.
+ *      // The semaphore can now be used.
+ *  }
+ * }
+ * @endcode
+ * \defgroup xSemaphoreCreateBinary xSemaphoreCreateBinary
+ * \ingroup Semaphores
+ */
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+    #define xSemaphoreCreateBinary()    xQueueGenericCreate( ( UBaseType_t ) 1, semSEMAPHORE_QUEUE_ITEM_LENGTH, queueQUEUE_TYPE_BINARY_SEMAPHORE )
+#endif
+
+/**
+ * semphr. h
+ * @code{c}
+ * SemaphoreHandle_t xSemaphoreCreateBinaryStatic( StaticSemaphore_t *pxSemaphoreBuffer );
+ * @endcode
+ *
+ * Creates a new binary semaphore instance, and returns a handle by which the
+ * new semaphore can be referenced.
+ *
+ * NOTE: In many usage scenarios it is faster and more memory efficient to use a
+ * direct to task notification in place of a binary semaphore!
+ * https://www.FreeRTOS.org/RTOS-task-notifications.html
+ *
+ * Internally, within the FreeRTOS implementation, binary semaphores use a block
+ * of memory, in which the semaphore structure is stored.  If a binary semaphore
+ * is created using xSemaphoreCreateBinary() then the required memory is
+ * automatically dynamically allocated inside the xSemaphoreCreateBinary()
+ * function.  (see https://www.FreeRTOS.org/a00111.html).  If a binary semaphore
+ * is created using xSemaphoreCreateBinaryStatic() then the application writer
+ * must provide the memory.  xSemaphoreCreateBinaryStatic() therefore allows a
+ * binary semaphore to be created without using any dynamic memory allocation.
+ *
+ * This type of semaphore can be used for pure synchronisation between tasks or
+ * between an interrupt and a task.  The semaphore need not be given back once
+ * obtained, so one task/interrupt can continuously 'give' the semaphore while
+ * another continuously 'takes' the semaphore.  For this reason this type of
+ * semaphore does not use a priority inheritance mechanism.  For an alternative
+ * that does use priority inheritance see xSemaphoreCreateMutex().
+ *
+ * @param pxSemaphoreBuffer Must point to a variable of type StaticSemaphore_t,
+ * which will then be used to hold the semaphore's data structure, removing the
+ * need for the memory to be allocated dynamically.
+ *
+ * @return If the semaphore is created then a handle to the created semaphore is
+ * returned.  If pxSemaphoreBuffer is NULL then NULL is returned.
+ *
+ * Example usage:
+ * @code{c}
+ * SemaphoreHandle_t xSemaphore = NULL;
+ * StaticSemaphore_t xSemaphoreBuffer;
+ *
+ * void vATask( void * pvParameters )
+ * {
+ *  // Semaphore cannot be used before a call to xSemaphoreCreateBinary().
+ *  // The semaphore's data structures will be placed in the xSemaphoreBuffer
+ *  // variable, the address of which is passed into the function.  The
+ *  // function's parameter is not NULL, so the function will not attempt any
+ *  // dynamic memory allocation, and therefore the function will not return
+ *  // return NULL.
+ *  xSemaphore = xSemaphoreCreateBinary( &xSemaphoreBuffer );
+ *
+ *  // Rest of task code goes here.
+ * }
+ * @endcode
+ * \defgroup xSemaphoreCreateBinaryStatic xSemaphoreCreateBinaryStatic
+ * \ingroup Semaphores
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    #define xSemaphoreCreateBinaryStatic( pxStaticSemaphore )    xQueueGenericCreateStatic( ( UBaseType_t ) 1, semSEMAPHORE_QUEUE_ITEM_LENGTH, NULL, ( StaticQueue_t * ) pxStaticSemaphore, queueQUEUE_TYPE_BINARY_SEMAPHORE )
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+
+/**
+ * semphr. h
+ * @code{c}
+ * xSemaphoreTake(
+ *                   SemaphoreHandle_t xSemaphore,
+ *                   TickType_t xBlockTime
+ *               );
+ * @endcode
+ *
+ * <i>Macro</i> to obtain a semaphore.  The semaphore must have previously been
+ * created with a call to xSemaphoreCreateBinary(), xSemaphoreCreateMutex() or
+ * xSemaphoreCreateCounting().
+ *
+ * @param xSemaphore A handle to the semaphore being taken - obtained when
+ * the semaphore was created.
+ *
+ * @param xBlockTime The time in ticks to wait for the semaphore to become
+ * available.  The macro portTICK_PERIOD_MS can be used to convert this to a
+ * real time.  A block time of zero can be used to poll the semaphore.  A block
+ * time of portMAX_DELAY can be used to block indefinitely (provided
+ * INCLUDE_vTaskSuspend is set to 1 in FreeRTOSConfig.h).
+ *
+ * @return pdTRUE if the semaphore was obtained.  pdFALSE
+ * if xBlockTime expired without the semaphore becoming available.
+ *
+ * Example usage:
+ * @code{c}
+ * SemaphoreHandle_t xSemaphore = NULL;
+ *
+ * // A task that creates a semaphore.
+ * void vATask( void * pvParameters )
+ * {
+ *  // Create the semaphore to guard a shared resource.
+ *  xSemaphore = xSemaphoreCreateBinary();
+ * }
+ *
+ * // A task that uses the semaphore.
+ * void vAnotherTask( void * pvParameters )
+ * {
+ *  // ... Do other things.
+ *
+ *  if( xSemaphore != NULL )
+ *  {
+ *      // See if we can obtain the semaphore.  If the semaphore is not available
+ *      // wait 10 ticks to see if it becomes free.
+ *      if( xSemaphoreTake( xSemaphore, ( TickType_t ) 10 ) == pdTRUE )
+ *      {
+ *          // We were able to obtain the semaphore and can now access the
+ *          // shared resource.
+ *
+ *          // ...
+ *
+ *          // We have finished accessing the shared resource.  Release the
+ *          // semaphore.
+ *          xSemaphoreGive( xSemaphore );
+ *      }
+ *      else
+ *      {
+ *          // We could not obtain the semaphore and can therefore not access
+ *          // the shared resource safely.
+ *      }
+ *  }
+ * }
+ * @endcode
+ * \defgroup xSemaphoreTake xSemaphoreTake
+ * \ingroup Semaphores
+ */
+#define xSemaphoreTake( xSemaphore, xBlockTime )    xQueueSemaphoreTake( ( xSemaphore ), ( xBlockTime ) )
+
 /**
  * semphr. h
  * @code{c}
@@ -137,6 +397,71 @@ typedef QueueHandle_t SemaphoreHandle_t;
 /**
  * semphr. h
  * @code{c}
+ * xSemaphoreGive( SemaphoreHandle_t xSemaphore );
+ * @endcode
+ *
+ * <i>Macro</i> to release a semaphore.  The semaphore must have previously been
+ * created with a call to xSemaphoreCreateBinary(), xSemaphoreCreateMutex() or
+ * xSemaphoreCreateCounting(). and obtained using sSemaphoreTake().
+ *
+ * This macro must not be used from an ISR.  See xSemaphoreGiveFromISR () for
+ * an alternative which can be used from an ISR.
+ *
+ * This macro must also not be used on semaphores created using
+ * xSemaphoreCreateRecursiveMutex().
+ *
+ * @param xSemaphore A handle to the semaphore being released.  This is the
+ * handle returned when the semaphore was created.
+ *
+ * @return pdTRUE if the semaphore was released.  pdFALSE if an error occurred.
+ * Semaphores are implemented using queues.  An error can occur if there is
+ * no space on the queue to post a message - indicating that the
+ * semaphore was not first obtained correctly.
+ *
+ * Example usage:
+ * @code{c}
+ * SemaphoreHandle_t xSemaphore = NULL;
+ *
+ * void vATask( void * pvParameters )
+ * {
+ *  // Create the semaphore to guard a shared resource.
+ *  xSemaphore = vSemaphoreCreateBinary();
+ *
+ *  if( xSemaphore != NULL )
+ *  {
+ *      if( xSemaphoreGive( xSemaphore ) != pdTRUE )
+ *      {
+ *          // We would expect this call to fail because we cannot give
+ *          // a semaphore without first "taking" it!
+ *      }
+ *
+ *      // Obtain the semaphore - don't block if the semaphore is not
+ *      // immediately available.
+ *      if( xSemaphoreTake( xSemaphore, ( TickType_t ) 0 ) )
+ *      {
+ *          // We now have the semaphore and can access the shared resource.
+ *
+ *          // ...
+ *
+ *          // We have finished accessing the shared resource so can free the
+ *          // semaphore.
+ *          if( xSemaphoreGive( xSemaphore ) != pdTRUE )
+ *          {
+ *              // We would not expect this call to fail because we must have
+ *              // obtained the semaphore to get here.
+ *          }
+ *      }
+ *  }
+ * }
+ * @endcode
+ * \defgroup xSemaphoreGive xSemaphoreGive
+ * \ingroup Semaphores
+ */
+#define xSemaphoreGive( xSemaphore )    xQueueGenericSend( ( QueueHandle_t ) ( xSemaphore ), NULL, semGIVE_BLOCK_TIME, queueSEND_TO_BACK )
+
+/**
+ * semphr. h
+ * @code{c}
  * xSemaphoreGiveRecursive( SemaphoreHandle_t xMutex );
  * @endcode
  *
@@ -221,6 +546,130 @@ typedef QueueHandle_t SemaphoreHandle_t;
 #if ( configUSE_RECURSIVE_MUTEXES == 1 )
     #define xSemaphoreGiveRecursive( xMutex )    xQueueGiveMutexRecursive( ( xMutex ) )
 #endif
+
+/**
+ * semphr. h
+ * @code{c}
+ * SemaphoreHandle_t xSemaphoreCreateMutex( void );
+ * @endcode
+ *
+ * Creates a new mutex type semaphore instance, and returns a handle by which
+ * the new mutex can be referenced.
+ *
+ * Internally, within the FreeRTOS implementation, mutex semaphores use a block
+ * of memory, in which the mutex structure is stored.  If a mutex is created
+ * using xSemaphoreCreateMutex() then the required memory is automatically
+ * dynamically allocated inside the xSemaphoreCreateMutex() function.  (see
+ * https://www.FreeRTOS.org/a00111.html).  If a mutex is created using
+ * xSemaphoreCreateMutexStatic() then the application writer must provided the
+ * memory.  xSemaphoreCreateMutexStatic() therefore allows a mutex to be created
+ * without using any dynamic memory allocation.
+ *
+ * Mutexes created using this function can be accessed using the xSemaphoreTake()
+ * and xSemaphoreGive() macros.  The xSemaphoreTakeRecursive() and
+ * xSemaphoreGiveRecursive() macros must not be used.
+ *
+ * This type of semaphore uses a priority inheritance mechanism so a task
+ * 'taking' a semaphore MUST ALWAYS 'give' the semaphore back once the
+ * semaphore it is no longer required.
+ *
+ * Mutex type semaphores cannot be used from within interrupt service routines.
+ *
+ * See xSemaphoreCreateBinary() for an alternative implementation that can be
+ * used for pure synchronisation (where one task or interrupt always 'gives' the
+ * semaphore and another always 'takes' the semaphore) and from within interrupt
+ * service routines.
+ *
+ * @return If the mutex was successfully created then a handle to the created
+ * semaphore is returned.  If there was not enough heap to allocate the mutex
+ * data structures then NULL is returned.
+ *
+ * Example usage:
+ * @code{c}
+ * SemaphoreHandle_t xSemaphore;
+ *
+ * void vATask( void * pvParameters )
+ * {
+ *  // Semaphore cannot be used before a call to xSemaphoreCreateMutex().
+ *  // This is a macro so pass the variable in directly.
+ *  xSemaphore = xSemaphoreCreateMutex();
+ *
+ *  if( xSemaphore != NULL )
+ *  {
+ *      // The semaphore was created successfully.
+ *      // The semaphore can now be used.
+ *  }
+ * }
+ * @endcode
+ * \defgroup xSemaphoreCreateMutex xSemaphoreCreateMutex
+ * \ingroup Semaphores
+ */
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+    #define xSemaphoreCreateMutex()    xQueueCreateMutex( queueQUEUE_TYPE_MUTEX )
+#endif
+
+/**
+ * semphr. h
+ * @code{c}
+ * SemaphoreHandle_t xSemaphoreCreateMutexStatic( StaticSemaphore_t *pxMutexBuffer );
+ * @endcode
+ *
+ * Creates a new mutex type semaphore instance, and returns a handle by which
+ * the new mutex can be referenced.
+ *
+ * Internally, within the FreeRTOS implementation, mutex semaphores use a block
+ * of memory, in which the mutex structure is stored.  If a mutex is created
+ * using xSemaphoreCreateMutex() then the required memory is automatically
+ * dynamically allocated inside the xSemaphoreCreateMutex() function.  (see
+ * https://www.FreeRTOS.org/a00111.html).  If a mutex is created using
+ * xSemaphoreCreateMutexStatic() then the application writer must provided the
+ * memory.  xSemaphoreCreateMutexStatic() therefore allows a mutex to be created
+ * without using any dynamic memory allocation.
+ *
+ * Mutexes created using this function can be accessed using the xSemaphoreTake()
+ * and xSemaphoreGive() macros.  The xSemaphoreTakeRecursive() and
+ * xSemaphoreGiveRecursive() macros must not be used.
+ *
+ * This type of semaphore uses a priority inheritance mechanism so a task
+ * 'taking' a semaphore MUST ALWAYS 'give' the semaphore back once the
+ * semaphore it is no longer required.
+ *
+ * Mutex type semaphores cannot be used from within interrupt service routines.
+ *
+ * See xSemaphoreCreateBinary() for an alternative implementation that can be
+ * used for pure synchronisation (where one task or interrupt always 'gives' the
+ * semaphore and another always 'takes' the semaphore) and from within interrupt
+ * service routines.
+ *
+ * @param pxMutexBuffer Must point to a variable of type StaticSemaphore_t,
+ * which will be used to hold the mutex's data structure, removing the need for
+ * the memory to be allocated dynamically.
+ *
+ * @return If the mutex was successfully created then a handle to the created
+ * mutex is returned.  If pxMutexBuffer was NULL then NULL is returned.
+ *
+ * Example usage:
+ * @code{c}
+ * SemaphoreHandle_t xSemaphore;
+ * StaticSemaphore_t xMutexBuffer;
+ *
+ * void vATask( void * pvParameters )
+ * {
+ *  // A mutex cannot be used before it has been created.  xMutexBuffer is
+ *  // into xSemaphoreCreateMutexStatic() so no dynamic memory allocation is
+ *  // attempted.
+ *  xSemaphore = xSemaphoreCreateMutexStatic( &xMutexBuffer );
+ *
+ *  // As no dynamic memory allocation was performed, xSemaphore cannot be NULL,
+ *  // so there is no need to check it.
+ * }
+ * @endcode
+ * \defgroup xSemaphoreCreateMutexStatic xSemaphoreCreateMutexStatic
+ * \ingroup Semaphores
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    #define xSemaphoreCreateMutexStatic( pxMutexBuffer )    xQueueCreateMutexStatic( queueQUEUE_TYPE_MUTEX, ( StaticQueue_t * ) ( pxMutexBuffer ) )
+#endif /* configSUPPORT_STATIC_ALLOCATION */
 
 /**
  * semphr. h
@@ -363,7 +812,176 @@ typedef QueueHandle_t SemaphoreHandle_t;
  * \ingroup Semaphores
  */
 #if ( ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configUSE_RECURSIVE_MUTEXES == 1 ) )
-    #define xSemaphoreCreateRecursiveMutexStatic( pxStaticSemaphore )    xQueueCreateMutexStatic( queueQUEUE_TYPE_RECURSIVE_MUTEX, ( StaticQueue_t * )pxStaticSemaphore )
+    #define xSemaphoreCreateRecursiveMutexStatic( pxStaticSemaphore )    xQueueCreateMutexStatic( queueQUEUE_TYPE_RECURSIVE_MUTEX, ( StaticQueue_t * ) pxStaticSemaphore )
+#endif /* configSUPPORT_STATIC_ALLOCATION */
+
+/**
+ * semphr. h
+ * @code{c}
+ * SemaphoreHandle_t xSemaphoreCreateCounting( UBaseType_t uxMaxCount, UBaseType_t uxInitialCount );
+ * @endcode
+ *
+ * Creates a new counting semaphore instance, and returns a handle by which the
+ * new counting semaphore can be referenced.
+ *
+ * In many usage scenarios it is faster and more memory efficient to use a
+ * direct to task notification in place of a counting semaphore!
+ * https://www.FreeRTOS.org/RTOS-task-notifications.html
+ *
+ * Internally, within the FreeRTOS implementation, counting semaphores use a
+ * block of memory, in which the counting semaphore structure is stored.  If a
+ * counting semaphore is created using xSemaphoreCreateCounting() then the
+ * required memory is automatically dynamically allocated inside the
+ * xSemaphoreCreateCounting() function.  (see
+ * https://www.FreeRTOS.org/a00111.html).  If a counting semaphore is created
+ * using xSemaphoreCreateCountingStatic() then the application writer can
+ * instead optionally provide the memory that will get used by the counting
+ * semaphore.  xSemaphoreCreateCountingStatic() therefore allows a counting
+ * semaphore to be created without using any dynamic memory allocation.
+ *
+ * Counting semaphores are typically used for two things:
+ *
+ * 1) Counting events.
+ *
+ *    In this usage scenario an event handler will 'give' a semaphore each time
+ *    an event occurs (incrementing the semaphore count value), and a handler
+ *    task will 'take' a semaphore each time it processes an event
+ *    (decrementing the semaphore count value).  The count value is therefore
+ *    the difference between the number of events that have occurred and the
+ *    number that have been processed.  In this case it is desirable for the
+ *    initial count value to be zero.
+ *
+ * 2) Resource management.
+ *
+ *    In this usage scenario the count value indicates the number of resources
+ *    available.  To obtain control of a resource a task must first obtain a
+ *    semaphore - decrementing the semaphore count value.  When the count value
+ *    reaches zero there are no free resources.  When a task finishes with the
+ *    resource it 'gives' the semaphore back - incrementing the semaphore count
+ *    value.  In this case it is desirable for the initial count value to be
+ *    equal to the maximum count value, indicating that all resources are free.
+ *
+ * @param uxMaxCount The maximum count value that can be reached.  When the
+ *        semaphore reaches this value it can no longer be 'given'.
+ *
+ * @param uxInitialCount The count value assigned to the semaphore when it is
+ *        created.
+ *
+ * @return Handle to the created semaphore.  Null if the semaphore could not be
+ *         created.
+ *
+ * Example usage:
+ * @code{c}
+ * SemaphoreHandle_t xSemaphore;
+ *
+ * void vATask( void * pvParameters )
+ * {
+ * SemaphoreHandle_t xSemaphore = NULL;
+ *
+ *  // Semaphore cannot be used before a call to xSemaphoreCreateCounting().
+ *  // The max value to which the semaphore can count should be 10, and the
+ *  // initial value assigned to the count should be 0.
+ *  xSemaphore = xSemaphoreCreateCounting( 10, 0 );
+ *
+ *  if( xSemaphore != NULL )
+ *  {
+ *      // The semaphore was created successfully.
+ *      // The semaphore can now be used.
+ *  }
+ * }
+ * @endcode
+ * \defgroup xSemaphoreCreateCounting xSemaphoreCreateCounting
+ * \ingroup Semaphores
+ */
+#if ( configSUPPORT_DYNAMIC_ALLOCATION == 1 )
+    #define xSemaphoreCreateCounting( uxMaxCount, uxInitialCount )    xQueueCreateCountingSemaphore( ( uxMaxCount ), ( uxInitialCount ) )
+#endif
+
+/**
+ * semphr. h
+ * @code{c}
+ * SemaphoreHandle_t xSemaphoreCreateCountingStatic( UBaseType_t uxMaxCount, UBaseType_t uxInitialCount, StaticSemaphore_t *pxSemaphoreBuffer );
+ * @endcode
+ *
+ * Creates a new counting semaphore instance, and returns a handle by which the
+ * new counting semaphore can be referenced.
+ *
+ * In many usage scenarios it is faster and more memory efficient to use a
+ * direct to task notification in place of a counting semaphore!
+ * https://www.FreeRTOS.org/RTOS-task-notifications.html
+ *
+ * Internally, within the FreeRTOS implementation, counting semaphores use a
+ * block of memory, in which the counting semaphore structure is stored.  If a
+ * counting semaphore is created using xSemaphoreCreateCounting() then the
+ * required memory is automatically dynamically allocated inside the
+ * xSemaphoreCreateCounting() function.  (see
+ * https://www.FreeRTOS.org/a00111.html).  If a counting semaphore is created
+ * using xSemaphoreCreateCountingStatic() then the application writer must
+ * provide the memory.  xSemaphoreCreateCountingStatic() therefore allows a
+ * counting semaphore to be created without using any dynamic memory allocation.
+ *
+ * Counting semaphores are typically used for two things:
+ *
+ * 1) Counting events.
+ *
+ *    In this usage scenario an event handler will 'give' a semaphore each time
+ *    an event occurs (incrementing the semaphore count value), and a handler
+ *    task will 'take' a semaphore each time it processes an event
+ *    (decrementing the semaphore count value).  The count value is therefore
+ *    the difference between the number of events that have occurred and the
+ *    number that have been processed.  In this case it is desirable for the
+ *    initial count value to be zero.
+ *
+ * 2) Resource management.
+ *
+ *    In this usage scenario the count value indicates the number of resources
+ *    available.  To obtain control of a resource a task must first obtain a
+ *    semaphore - decrementing the semaphore count value.  When the count value
+ *    reaches zero there are no free resources.  When a task finishes with the
+ *    resource it 'gives' the semaphore back - incrementing the semaphore count
+ *    value.  In this case it is desirable for the initial count value to be
+ *    equal to the maximum count value, indicating that all resources are free.
+ *
+ * @param uxMaxCount The maximum count value that can be reached.  When the
+ *        semaphore reaches this value it can no longer be 'given'.
+ *
+ * @param uxInitialCount The count value assigned to the semaphore when it is
+ *        created.
+ *
+ * @param pxSemaphoreBuffer Must point to a variable of type StaticSemaphore_t,
+ * which will then be used to hold the semaphore's data structure, removing the
+ * need for the memory to be allocated dynamically.
+ *
+ * @return If the counting semaphore was successfully created then a handle to
+ * the created counting semaphore is returned.  If pxSemaphoreBuffer was NULL
+ * then NULL is returned.
+ *
+ * Example usage:
+ * @code{c}
+ * SemaphoreHandle_t xSemaphore;
+ * StaticSemaphore_t xSemaphoreBuffer;
+ *
+ * void vATask( void * pvParameters )
+ * {
+ * SemaphoreHandle_t xSemaphore = NULL;
+ *
+ *  // Counting semaphore cannot be used before they have been created.  Create
+ *  // a counting semaphore using xSemaphoreCreateCountingStatic().  The max
+ *  // value to which the semaphore can count is 10, and the initial value
+ *  // assigned to the count will be 0.  The address of xSemaphoreBuffer is
+ *  // passed in and will be used to hold the semaphore structure, so no dynamic
+ *  // memory allocation will be used.
+ *  xSemaphore = xSemaphoreCreateCounting( 10, 0, &xSemaphoreBuffer );
+ *
+ *  // No memory allocation was attempted so xSemaphore cannot be NULL, so there
+ *  // is no need to check its value.
+ * }
+ * @endcode
+ * \defgroup xSemaphoreCreateCountingStatic xSemaphoreCreateCountingStatic
+ * \ingroup Semaphores
+ */
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 )
+    #define xSemaphoreCreateCountingStatic( uxMaxCount, uxInitialCount, pxSemaphoreBuffer )    xQueueCreateCountingSemaphoreStatic( ( uxMaxCount ), ( uxInitialCount ), ( StaticQueue_t * ) ( pxSemaphoreBuffer ) )
 #endif /* configSUPPORT_STATIC_ALLOCATION */
 
 /**

--- a/test/test_mutex_dynamic.c
+++ b/test/test_mutex_dynamic.c
@@ -37,7 +37,7 @@ static void rt_thread_entry1(void *parameter)
     while (1)
     {
         /* pending the mutex */
-        xSemaphoreTakeRecursive(dynamic_mutex, portMAX_DELAY);
+        xSemaphoreTake(dynamic_mutex, portMAX_DELAY);
         /* protect and deal with public variables */
         number1++;
         rt_thread_mdelay(10);
@@ -51,7 +51,7 @@ static void rt_thread_entry1(void *parameter)
             rt_kprintf("mutex protect ,number1 = mumber2 is %d\n", number1);
         }
         /* release the mutex */
-        xSemaphoreGiveRecursive(dynamic_mutex);
+        xSemaphoreGive(dynamic_mutex);
 
         if (number1 >= 100)
         {
@@ -68,10 +68,10 @@ static void rt_thread_entry2(void *parameter)
 {
     while (1)
     {
-        xSemaphoreTakeRecursive(dynamic_mutex, portMAX_DELAY);
+        xSemaphoreTake(dynamic_mutex, portMAX_DELAY);
         number1++;
         number2++;
-        xSemaphoreGiveRecursive(dynamic_mutex);
+        xSemaphoreGive(dynamic_mutex);
 
         if (number1 >= 50)
             return;
@@ -82,7 +82,7 @@ static void rt_thread_entry2(void *parameter)
 int mutex_dynamic(void)
 {
     /* 创建一个动态互斥量 */
-    dynamic_mutex = xSemaphoreCreateRecursiveMutex();
+    dynamic_mutex = xSemaphoreCreateMutex();
     if (dynamic_mutex == RT_NULL)
     {
         rt_kprintf("create dynamic mutex failed.\n");

--- a/test/test_mutex_dynamic.c
+++ b/test/test_mutex_dynamic.c
@@ -10,12 +10,10 @@
  */
 
 /*
- * Demo: mutex(es)
+ * Demo: mutex
  *
- * This demo demonstrates how the mutex manage the shared resource.
+ * This demo demonstrates dynamically creating a mutex and using it to manage shared resources.
  *
- * read more:
- *    https://www.rt-thread.io/document/site/thread-sync/thread-sync/#mutex
  */
 
 #include <rtthread.h>
@@ -78,10 +76,9 @@ static void rt_thread_entry2(void *parameter)
     }
 }
 
-/* 互斥量示例的初始化 */
 int mutex_dynamic(void)
 {
-    /* 创建一个动态互斥量 */
+    /* Create a mutex dynamically */
     dynamic_mutex = xSemaphoreCreateMutex();
     if (dynamic_mutex == RT_NULL)
     {
@@ -109,5 +106,4 @@ int mutex_dynamic(void)
     return 0;
 }
 
-/* 导出到 msh 命令列表中 */
 MSH_CMD_EXPORT(mutex_dynamic, mutex sample);

--- a/test/test_mutex_recursive_dynamic.c
+++ b/test/test_mutex_recursive_dynamic.c
@@ -10,12 +10,10 @@
  */
 
 /*
- * Demo: mutex(es)
+ * Demo: recursive mutex
  *
- * This demo demonstrates how the mutex manage the shared resource.
+ * This demo demonstrates dynamically creating a recursive mutex and using it to manage shared resources.
  *
- * read more:
- *    https://www.rt-thread.io/document/site/thread-sync/thread-sync/#mutex
  */
 
 #include <rtthread.h>
@@ -78,10 +76,9 @@ static void rt_thread_entry2(void *parameter)
     }
 }
 
-/* 互斥量示例的初始化 */
 int mutex_recursive_dynamic(void)
 {
-    /* 创建一个动态互斥量 */
+    /* Create a recursive mutex dynamically */
     dynamic_mutex = xSemaphoreCreateRecursiveMutex();
     if (dynamic_mutex == RT_NULL)
     {
@@ -109,5 +106,4 @@ int mutex_recursive_dynamic(void)
     return 0;
 }
 
-/* 导出到 msh 命令列表中 */
 MSH_CMD_EXPORT(mutex_recursive_dynamic, mutex sample);

--- a/test/test_mutex_recursive_dynamic.c
+++ b/test/test_mutex_recursive_dynamic.c
@@ -26,8 +26,7 @@
 #define THREAD_TIMESLICE        5
 
 /* mutex handler */
-static SemaphoreHandle_t static_mutex = RT_NULL;
-static StaticSemaphore_t xMutexBuffer;
+static SemaphoreHandle_t dynamic_mutex = RT_NULL;
 static rt_uint8_t number1, number2 = 0;
 
 ALIGN(RT_ALIGN_SIZE)
@@ -38,7 +37,7 @@ static void rt_thread_entry1(void *parameter)
     while (1)
     {
         /* pending the mutex */
-        xSemaphoreTake(static_mutex, portMAX_DELAY);
+        xSemaphoreTakeRecursive(dynamic_mutex, portMAX_DELAY);
         /* protect and deal with public variables */
         number1++;
         rt_thread_mdelay(10);
@@ -52,11 +51,11 @@ static void rt_thread_entry1(void *parameter)
             rt_kprintf("mutex protect ,number1 = mumber2 is %d\n", number1);
         }
         /* release the mutex */
-        xSemaphoreGive(static_mutex);
+        xSemaphoreGiveRecursive(dynamic_mutex);
 
         if (number1 >= 100)
         {
-            vSemaphoreDelete(static_mutex);
+            vSemaphoreDelete(dynamic_mutex);
             return;
         }
     }
@@ -69,10 +68,10 @@ static void rt_thread_entry2(void *parameter)
 {
     while (1)
     {
-        xSemaphoreTake(static_mutex, portMAX_DELAY);
+        xSemaphoreTakeRecursive(dynamic_mutex, portMAX_DELAY);
         number1++;
         number2++;
-        xSemaphoreGive(static_mutex);
+        xSemaphoreGiveRecursive(dynamic_mutex);
 
         if (number1 >= 50)
             return;
@@ -80,11 +79,11 @@ static void rt_thread_entry2(void *parameter)
 }
 
 /* 互斥量示例的初始化 */
-int mutex_static(void)
+int mutex_recursive_dynamic(void)
 {
     /* 创建一个动态互斥量 */
-    static_mutex = xSemaphoreCreateMutexStatic(&xMutexBuffer);
-    if (static_mutex == RT_NULL)
+    dynamic_mutex = xSemaphoreCreateRecursiveMutex();
+    if (dynamic_mutex == RT_NULL)
     {
         rt_kprintf("create dynamic mutex failed.\n");
         return -1;
@@ -111,4 +110,4 @@ int mutex_static(void)
 }
 
 /* 导出到 msh 命令列表中 */
-MSH_CMD_EXPORT(mutex_static, mutex sample);
+MSH_CMD_EXPORT(mutex_recursive_dynamic, mutex sample);

--- a/test/test_mutex_recursive_static.c
+++ b/test/test_mutex_recursive_static.c
@@ -10,12 +10,10 @@
  */
 
 /*
- * Demo: mutex(es)
+ * Demo: recursive mutex
  *
- * This demo demonstrates how the mutex manage the shared resource.
+ * This demo demonstrates statically creating a recursive mutex and using it to manage shared resources.
  *
- * read more:
- *    https://www.rt-thread.io/document/site/thread-sync/thread-sync/#mutex
  */
 
 #include <rtthread.h>
@@ -27,6 +25,7 @@
 
 /* mutex handler */
 static SemaphoreHandle_t static_mutex = RT_NULL;
+/* Buffer to store mutex structure */
 static StaticSemaphore_t xMutexBuffer;
 static rt_uint8_t number1, number2 = 0;
 
@@ -79,10 +78,9 @@ static void rt_thread_entry2(void *parameter)
     }
 }
 
-/* 互斥量示例的初始化 */
 int mutex_recursive_static(void)
 {
-    /* 创建一个动态互斥量 */
+    /* Create a static recursive mutex */
     static_mutex = xSemaphoreCreateRecursiveMutexStatic(&xMutexBuffer);
     if (static_mutex == RT_NULL)
     {
@@ -110,5 +108,4 @@ int mutex_recursive_static(void)
     return 0;
 }
 
-/* 导出到 msh 命令列表中 */
 MSH_CMD_EXPORT(mutex_recursive_static, mutex sample);

--- a/test/test_mutex_recursive_static.c
+++ b/test/test_mutex_recursive_static.c
@@ -38,7 +38,7 @@ static void rt_thread_entry1(void *parameter)
     while (1)
     {
         /* pending the mutex */
-        xSemaphoreTake(static_mutex, portMAX_DELAY);
+        xSemaphoreTakeRecursive(static_mutex, portMAX_DELAY);
         /* protect and deal with public variables */
         number1++;
         rt_thread_mdelay(10);
@@ -52,7 +52,7 @@ static void rt_thread_entry1(void *parameter)
             rt_kprintf("mutex protect ,number1 = mumber2 is %d\n", number1);
         }
         /* release the mutex */
-        xSemaphoreGive(static_mutex);
+        xSemaphoreGiveRecursive(static_mutex);
 
         if (number1 >= 100)
         {
@@ -69,10 +69,10 @@ static void rt_thread_entry2(void *parameter)
 {
     while (1)
     {
-        xSemaphoreTake(static_mutex, portMAX_DELAY);
+        xSemaphoreTakeRecursive(static_mutex, portMAX_DELAY);
         number1++;
         number2++;
-        xSemaphoreGive(static_mutex);
+        xSemaphoreGiveRecursive(static_mutex);
 
         if (number1 >= 50)
             return;
@@ -80,10 +80,10 @@ static void rt_thread_entry2(void *parameter)
 }
 
 /* 互斥量示例的初始化 */
-int mutex_static(void)
+int mutex_recursive_static(void)
 {
     /* 创建一个动态互斥量 */
-    static_mutex = xSemaphoreCreateMutexStatic(&xMutexBuffer);
+    static_mutex = xSemaphoreCreateRecursiveMutexStatic(&xMutexBuffer);
     if (static_mutex == RT_NULL)
     {
         rt_kprintf("create dynamic mutex failed.\n");
@@ -111,4 +111,4 @@ int mutex_static(void)
 }
 
 /* 导出到 msh 命令列表中 */
-MSH_CMD_EXPORT(mutex_static, mutex sample);
+MSH_CMD_EXPORT(mutex_recursive_static, mutex sample);

--- a/test/test_mutex_recursive_static.c
+++ b/test/test_mutex_recursive_static.c
@@ -80,11 +80,11 @@ static void rt_thread_entry2(void *parameter)
 
 int mutex_recursive_static(void)
 {
-    /* Create a static recursive mutex */
+    /* Create a recursive mutex statically */
     static_mutex = xSemaphoreCreateRecursiveMutexStatic(&xMutexBuffer);
     if (static_mutex == RT_NULL)
     {
-        rt_kprintf("create dynamic mutex failed.\n");
+        rt_kprintf("create static mutex failed.\n");
         return -1;
     }
 

--- a/test/test_mutex_static.c
+++ b/test/test_mutex_static.c
@@ -10,12 +10,10 @@
  */
 
 /*
- * Demo: mutex(es)
+ * Demo: mutex
  *
- * This demo demonstrates how the mutex manage the shared resource.
+ * This demo demonstrates statically creating a mutex and using it to manage shared resources.
  *
- * read more:
- *    https://www.rt-thread.io/document/site/thread-sync/thread-sync/#mutex
  */
 
 #include <rtthread.h>
@@ -27,6 +25,7 @@
 
 /* mutex handler */
 static SemaphoreHandle_t static_mutex = RT_NULL;
+/* Buffer to store mutex structure */
 static StaticSemaphore_t xMutexBuffer;
 static rt_uint8_t number1, number2 = 0;
 
@@ -79,14 +78,13 @@ static void rt_thread_entry2(void *parameter)
     }
 }
 
-/* 互斥量示例的初始化 */
 int mutex_static(void)
 {
-    /* 创建一个动态互斥量 */
+    /* Create a mutex statically */
     static_mutex = xSemaphoreCreateMutexStatic(&xMutexBuffer);
     if (static_mutex == RT_NULL)
     {
-        rt_kprintf("create dynamic mutex failed.\n");
+        rt_kprintf("create static mutex failed.\n");
         return -1;
     }
 
@@ -110,5 +108,4 @@ int mutex_static(void)
     return 0;
 }
 
-/* 导出到 msh 命令列表中 */
 MSH_CMD_EXPORT(mutex_static, mutex sample);

--- a/test/test_semaphore_binary_dynamic.c
+++ b/test/test_semaphore_binary_dynamic.c
@@ -9,11 +9,14 @@
  */
 
 /*
- * 程序清单：信号量例程
+ * Demo: semaphore
+ * This demo creates one binary semaphore dynamically
+ * It creates two threads:
+ *    1) thread #1: give the semaphore
+ *    2) thread #2: take the semaphore
  *
- * 该例程创建了一个动态信号量，初始化两个线程，线程1在count每计数10次时，
- * 发送一个信号量，线程2在接收信号量后，对number进行加1操作
  */
+
 #include <rtthread.h>
 #include <FreeRTOS.h>
 #include <semphr.h>
@@ -21,7 +24,7 @@
 #define THREAD_PRIORITY         25
 #define THREAD_TIMESLICE        5
 
-/* 指向信号量的指针 */
+/* Semaphore handle */
 static SemaphoreHandle_t dynamic_sem = RT_NULL;
 
 ALIGN(RT_ALIGN_SIZE)
@@ -41,7 +44,7 @@ static void rt_thread1_entry(void *parameter)
         else
             return;
 
-        /* count每计数10次，就释放一次信号量 */
+        /* Release the semaphore when count is incremented by 10 */
         if (0 == (count % 10))
         {
             rt_kprintf("thread1 release a dynamic semaphore.\n");
@@ -64,7 +67,7 @@ static void rt_thread2_entry(void *parameter)
     static rt_uint8_t number = 0;
     while (1)
     {
-        /* 永久方式等待信号量，获取到信号量，则执行number自加的操作 */
+        /* Block on the semaphore indefinitely. Increment number after taking the semaphore */
         result = xSemaphoreTake(dynamic_sem, portMAX_DELAY);
         if (result != pdPASS)
         {
@@ -79,10 +82,9 @@ static void rt_thread2_entry(void *parameter)
     }
 }
 
-/* 信号量示例的初始化 */
 int semaphore_binary_dynamic()
 {
-    /* 创建一个动态信号量，初始值是0 */
+    /* Create a binary semaphore dynamically */
     dynamic_sem = xSemaphoreCreateBinary();
     if (dynamic_sem == RT_NULL)
     {
@@ -110,5 +112,4 @@ int semaphore_binary_dynamic()
     return 0;
 }
 
-/* 导出到 msh 命令列表中 */
 MSH_CMD_EXPORT(semaphore_binary_dynamic, semaphore sample);

--- a/test/test_semaphore_binary_dynamic.c
+++ b/test/test_semaphore_binary_dynamic.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2006-2022, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2018-08-24     yangjie      the first version
+ */
+
+/*
+ * 程序清单：信号量例程
+ *
+ * 该例程创建了一个动态信号量，初始化两个线程，线程1在count每计数10次时，
+ * 发送一个信号量，线程2在接收信号量后，对number进行加1操作
+ */
+#include <rtthread.h>
+#include <FreeRTOS.h>
+#include <semphr.h>
+
+#define THREAD_PRIORITY         25
+#define THREAD_TIMESLICE        5
+
+/* 指向信号量的指针 */
+static SemaphoreHandle_t dynamic_sem = RT_NULL;
+
+ALIGN(RT_ALIGN_SIZE)
+static char thread1_stack[1024];
+static struct rt_thread thread1;
+static void rt_thread1_entry(void *parameter)
+{
+    static rt_err_t result;
+    static rt_uint8_t count = 0;
+
+    while (1)
+    {
+        if (count <= 100)
+        {
+            count++;
+        }
+        else
+            return;
+
+        /* count每计数10次，就释放一次信号量 */
+        if (0 == (count % 10))
+        {
+            rt_kprintf("thread1 release a dynamic semaphore.\n");
+            result = xSemaphoreGive(dynamic_sem);
+            if (result != pdPASS)
+            {
+                rt_kprintf("thread2 take a dynamic semaphore, failed.\n");
+                return;
+            }
+        }
+    }
+}
+
+ALIGN(RT_ALIGN_SIZE)
+static char thread2_stack[1024];
+static struct rt_thread thread2;
+static void rt_thread2_entry(void *parameter)
+{
+    static rt_err_t result;
+    static rt_uint8_t number = 0;
+    while (1)
+    {
+        /* 永久方式等待信号量，获取到信号量，则执行number自加的操作 */
+        result = xSemaphoreTake(dynamic_sem, portMAX_DELAY);
+        if (result != pdPASS)
+        {
+            rt_kprintf("thread2 take a dynamic semaphore, failed.\n");
+            return;
+        }
+        else
+        {
+            number++;
+            rt_kprintf("thread2 take a dynamic semaphore. number = %d\n", number);
+        }
+    }
+}
+
+/* 信号量示例的初始化 */
+int semaphore_binary_dynamic()
+{
+    /* 创建一个动态信号量，初始值是0 */
+    dynamic_sem = xSemaphoreCreateBinary();
+    if (dynamic_sem == RT_NULL)
+    {
+        rt_kprintf("create dynamic semaphore failed.\n");
+        return -1;
+    }
+    rt_thread_init(&thread1,
+                   "thread1",
+                   rt_thread1_entry,
+                   RT_NULL,
+                   &thread1_stack[0],
+                   sizeof(thread1_stack),
+                   THREAD_PRIORITY, THREAD_TIMESLICE);
+    rt_thread_startup(&thread1);
+
+    rt_thread_init(&thread2,
+                   "thread2",
+                   rt_thread2_entry,
+                   RT_NULL,
+                   &thread2_stack[0],
+                   sizeof(thread2_stack),
+                   THREAD_PRIORITY - 1, THREAD_TIMESLICE);
+    rt_thread_startup(&thread2);
+
+    return 0;
+}
+
+/* 导出到 msh 命令列表中 */
+MSH_CMD_EXPORT(semaphore_binary_dynamic, semaphore sample);

--- a/test/test_semaphore_binary_static.c
+++ b/test/test_semaphore_binary_static.c
@@ -9,11 +9,14 @@
  */
 
 /*
- * 程序清单：信号量例程
+ * Demo: semaphore
+ * This demo creates one binary semaphore statically
+ * It creates two threads:
+ *    1) thread #1: give the semaphore
+ *    2) thread #2: take the semaphore
  *
- * 该例程创建了一个动态信号量，初始化两个线程，线程1在count每计数10次时，
- * 发送一个信号量，线程2在接收信号量后，对number进行加1操作
  */
+
 #include <rtthread.h>
 #include <FreeRTOS.h>
 #include <semphr.h>
@@ -21,8 +24,9 @@
 #define THREAD_PRIORITY         25
 #define THREAD_TIMESLICE        5
 
-/* 指向信号量的指针 */
+/* Semaphore handle */
 static SemaphoreHandle_t static_sem = RT_NULL;
+/* Buffer to store semaphore structure */
 static StaticSemaphore_t xMutexBuffer;
 
 ALIGN(RT_ALIGN_SIZE)
@@ -42,7 +46,7 @@ static void rt_thread1_entry(void *parameter)
         else
             return;
 
-        /* count每计数10次，就释放一次信号量 */
+        /* Release the semaphore when count is incremented by 10 */
         if (0 == (count % 10))
         {
             rt_kprintf("thread1 release a static semaphore.\n");
@@ -65,7 +69,7 @@ static void rt_thread2_entry(void *parameter)
     static rt_uint8_t number = 0;
     while (1)
     {
-        /* 永久方式等待信号量，获取到信号量，则执行number自加的操作 */
+        /* Block on the semaphore indefinitely. Increment number after taking the semaphore */
         result = xSemaphoreTake(static_sem, portMAX_DELAY);
         if (result != pdPASS)
         {
@@ -80,10 +84,9 @@ static void rt_thread2_entry(void *parameter)
     }
 }
 
-/* 信号量示例的初始化 */
 int semaphore_binary_static()
 {
-    /* 创建一个动态信号量，初始值是0 */
+    /* Create a binary semaphore statically */
     static_sem = xSemaphoreCreateBinaryStatic(&xMutexBuffer);
     if (static_sem == RT_NULL)
     {
@@ -111,5 +114,4 @@ int semaphore_binary_static()
     return 0;
 }
 
-/* 导出到 msh 命令列表中 */
 MSH_CMD_EXPORT(semaphore_binary_static, semaphore sample);

--- a/test/test_semaphore_binary_static.c
+++ b/test/test_semaphore_binary_static.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2006-2022, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2018-08-24     yangjie      the first version
+ */
+
+/*
+ * 程序清单：信号量例程
+ *
+ * 该例程创建了一个动态信号量，初始化两个线程，线程1在count每计数10次时，
+ * 发送一个信号量，线程2在接收信号量后，对number进行加1操作
+ */
+#include <rtthread.h>
+#include <FreeRTOS.h>
+#include <semphr.h>
+
+#define THREAD_PRIORITY         25
+#define THREAD_TIMESLICE        5
+
+/* 指向信号量的指针 */
+static SemaphoreHandle_t static_sem = RT_NULL;
+static StaticSemaphore_t xMutexBuffer;
+
+ALIGN(RT_ALIGN_SIZE)
+static char thread1_stack[1024];
+static struct rt_thread thread1;
+static void rt_thread1_entry(void *parameter)
+{
+    static rt_err_t result;
+    static rt_uint8_t count = 0;
+
+    while (1)
+    {
+        if (count <= 100)
+        {
+            count++;
+        }
+        else
+            return;
+
+        /* count每计数10次，就释放一次信号量 */
+        if (0 == (count % 10))
+        {
+            rt_kprintf("thread1 release a static semaphore.\n");
+            result = xSemaphoreGive(static_sem);
+            if (result != pdPASS)
+            {
+                rt_kprintf("thread2 take a static semaphore, failed.\n");
+                return;
+            }
+        }
+    }
+}
+
+ALIGN(RT_ALIGN_SIZE)
+static char thread2_stack[1024];
+static struct rt_thread thread2;
+static void rt_thread2_entry(void *parameter)
+{
+    static rt_err_t result;
+    static rt_uint8_t number = 0;
+    while (1)
+    {
+        /* 永久方式等待信号量，获取到信号量，则执行number自加的操作 */
+        result = xSemaphoreTake(static_sem, portMAX_DELAY);
+        if (result != pdPASS)
+        {
+            rt_kprintf("thread2 take a static semaphore, failed.\n");
+            return;
+        }
+        else
+        {
+            number++;
+            rt_kprintf("thread2 take a static semaphore. number = %d\n", number);
+        }
+    }
+}
+
+/* 信号量示例的初始化 */
+int semaphore_binary_static()
+{
+    /* 创建一个动态信号量，初始值是0 */
+    static_sem = xSemaphoreCreateBinaryStatic(&xMutexBuffer);
+    if (static_sem == RT_NULL)
+    {
+        rt_kprintf("create static semaphore failed.\n");
+        return -1;
+    }
+    rt_thread_init(&thread1,
+                   "thread1",
+                   rt_thread1_entry,
+                   RT_NULL,
+                   &thread1_stack[0],
+                   sizeof(thread1_stack),
+                   THREAD_PRIORITY, THREAD_TIMESLICE);
+    rt_thread_startup(&thread1);
+
+    rt_thread_init(&thread2,
+                   "thread2",
+                   rt_thread2_entry,
+                   RT_NULL,
+                   &thread2_stack[0],
+                   sizeof(thread2_stack),
+                   THREAD_PRIORITY - 1, THREAD_TIMESLICE);
+    rt_thread_startup(&thread2);
+
+    return 0;
+}
+
+/* 导出到 msh 命令列表中 */
+MSH_CMD_EXPORT(semaphore_binary_static, semaphore sample);

--- a/test/test_semaphore_counting_dynamic.c
+++ b/test/test_semaphore_counting_dynamic.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2006-2022, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2018-08-24     yangjie      the first version
+ */
+
+/*
+ * 程序清单：信号量例程
+ *
+ * 该例程创建了一个动态信号量，初始化两个线程，线程1在count每计数10次时，
+ * 发送一个信号量，线程2在接收信号量后，对number进行加1操作
+ */
+#include <rtthread.h>
+#include <FreeRTOS.h>
+#include <semphr.h>
+
+#define THREAD_PRIORITY         25
+#define THREAD_TIMESLICE        5
+
+/* 指向信号量的指针 */
+static SemaphoreHandle_t dynamic_sem = RT_NULL;
+
+ALIGN(RT_ALIGN_SIZE)
+static char thread1_stack[1024];
+static struct rt_thread thread1;
+static void rt_thread1_entry(void *parameter)
+{
+    static rt_err_t result;
+    static rt_uint8_t number = 0;
+    while (1)
+    {
+        for (number = 0; number < 5; number++)
+        {
+            result = xSemaphoreTake(dynamic_sem, portMAX_DELAY);
+            if (result != pdPASS)
+            {
+                rt_kprintf("thread1 take a dynamic semaphore, failed.\n");
+                return;
+            }
+            else
+            {
+                rt_kprintf("thread1 take a dynamic semaphore. number = %d\n", number);
+            }
+        }
+        result = xSemaphoreTake(dynamic_sem, 0);
+        if (result != errQUEUE_EMPTY)
+        {
+            rt_kprintf("thread1 take a dynamic semaphore. number = %d. Should not succeed.\n", number);
+        }
+        rt_thread_delay(rt_tick_from_millisecond(10000));
+    }
+}
+
+ALIGN(RT_ALIGN_SIZE)
+static char thread2_stack[1024];
+static struct rt_thread thread2;
+static void rt_thread2_entry(void *parameter)
+{
+    static rt_err_t result;
+    static rt_uint8_t number = 0;
+    while (1)
+    {
+        for (number = 0; number < 5; number++)
+        {
+            result = xSemaphoreGive(dynamic_sem);
+            if (result != pdPASS)
+            {
+                rt_kprintf("thread2 release a dynamic semaphore, failed.\n");
+                return;
+            }
+            else
+            {
+                rt_kprintf("thread2 release a dynamic semaphore. number = %d\n", number);
+            }
+        }
+        result = xSemaphoreGive(dynamic_sem);
+        if (result != errQUEUE_FULL)
+        {
+            rt_kprintf("thread2 release a dynamic semaphore. number = %d. Should not succeed.\n", number);
+        }
+        rt_thread_delay(rt_tick_from_millisecond(10000));
+    }
+}
+
+/* 信号量示例的初始化 */
+int semaphore_counting_dynamic()
+{
+    /* 创建一个动态信号量，初始值是0 */
+    dynamic_sem = xSemaphoreCreateCounting(5, 0);
+    if (dynamic_sem == RT_NULL)
+    {
+        rt_kprintf("create dynamic semaphore failed.\n");
+        return -1;
+    }
+    rt_thread_init(&thread1,
+                   "thread1",
+                   rt_thread1_entry,
+                   RT_NULL,
+                   &thread1_stack[0],
+                   sizeof(thread1_stack),
+                   THREAD_PRIORITY, THREAD_TIMESLICE);
+    rt_thread_startup(&thread1);
+
+    rt_thread_init(&thread2,
+                   "thread2",
+                   rt_thread2_entry,
+                   RT_NULL,
+                   &thread2_stack[0],
+                   sizeof(thread2_stack),
+                   THREAD_PRIORITY - 1, THREAD_TIMESLICE);
+    rt_thread_startup(&thread2);
+
+    return 0;
+}
+
+/* 导出到 msh 命令列表中 */
+MSH_CMD_EXPORT(semaphore_counting_dynamic, semaphore sample);

--- a/test/test_semaphore_counting_dynamic.c
+++ b/test/test_semaphore_counting_dynamic.c
@@ -9,11 +9,14 @@
  */
 
 /*
- * 程序清单：信号量例程
+ * Demo: semaphore
+ * This demo creates one counting semaphore dynamically
+ * It creates two threads:
+ *    1) thread #1: take the semaphore until its value reaches 0
+ *    2) thread #2: give the semaphore until its value reaches maximum
  *
- * 该例程创建了一个动态信号量，初始化两个线程，线程1在count每计数10次时，
- * 发送一个信号量，线程2在接收信号量后，对number进行加1操作
  */
+
 #include <rtthread.h>
 #include <FreeRTOS.h>
 #include <semphr.h>
@@ -21,7 +24,7 @@
 #define THREAD_PRIORITY         25
 #define THREAD_TIMESLICE        5
 
-/* 指向信号量的指针 */
+/* Semaphore handle */
 static SemaphoreHandle_t dynamic_sem = RT_NULL;
 
 ALIGN(RT_ALIGN_SIZE)
@@ -33,6 +36,7 @@ static void rt_thread1_entry(void *parameter)
     static rt_uint8_t number = 0;
     while (1)
     {
+        /* Thread1 starts when thread2 is delayed. Semaphore value is 5. Should take it successfully for five times */
         for (number = 0; number < 5; number++)
         {
             result = xSemaphoreTake(dynamic_sem, portMAX_DELAY);
@@ -46,6 +50,7 @@ static void rt_thread1_entry(void *parameter)
                 rt_kprintf("thread1 take a dynamic semaphore. number = %d\n", number);
             }
         }
+        /* Cannot take the semaphore for the sixth time because the value is 0 */
         result = xSemaphoreTake(dynamic_sem, 0);
         if (result != errQUEUE_EMPTY)
         {
@@ -64,6 +69,7 @@ static void rt_thread2_entry(void *parameter)
     static rt_uint8_t number = 0;
     while (1)
     {
+        /* Thread2 runs before thread1. The semaphore value is 0. Should give the semaphore 5 times successfully */
         for (number = 0; number < 5; number++)
         {
             result = xSemaphoreGive(dynamic_sem);
@@ -77,6 +83,7 @@ static void rt_thread2_entry(void *parameter)
                 rt_kprintf("thread2 release a dynamic semaphore. number = %d\n", number);
             }
         }
+        /* Cannot give the semaphore for the sixth time because the max value is reached */
         result = xSemaphoreGive(dynamic_sem);
         if (result != errQUEUE_FULL)
         {
@@ -86,10 +93,9 @@ static void rt_thread2_entry(void *parameter)
     }
 }
 
-/* 信号量示例的初始化 */
 int semaphore_counting_dynamic()
 {
-    /* 创建一个动态信号量，初始值是0 */
+    /* Create a counting semaphore dynamically. Max value is 5. Initial value is 0. */
     dynamic_sem = xSemaphoreCreateCounting(5, 0);
     if (dynamic_sem == RT_NULL)
     {
@@ -117,5 +123,4 @@ int semaphore_counting_dynamic()
     return 0;
 }
 
-/* 导出到 msh 命令列表中 */
 MSH_CMD_EXPORT(semaphore_counting_dynamic, semaphore sample);

--- a/test/test_semaphore_counting_static.c
+++ b/test/test_semaphore_counting_static.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2006-2022, RT-Thread Development Team
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Change Logs:
+ * Date           Author       Notes
+ * 2018-08-24     yangjie      the first version
+ */
+
+/*
+ * 程序清单：信号量例程
+ *
+ * 该例程创建了一个动态信号量，初始化两个线程，线程1在count每计数10次时，
+ * 发送一个信号量，线程2在接收信号量后，对number进行加1操作
+ */
+#include <rtthread.h>
+#include <FreeRTOS.h>
+#include <semphr.h>
+
+#define THREAD_PRIORITY         25
+#define THREAD_TIMESLICE        5
+
+/* 指向信号量的指针 */
+static SemaphoreHandle_t static_sem = RT_NULL;
+static StaticSemaphore_t xMutexBuffer;
+
+ALIGN(RT_ALIGN_SIZE)
+static char thread1_stack[1024];
+static struct rt_thread thread1;
+static void rt_thread1_entry(void *parameter)
+{
+    static rt_err_t result;
+    static rt_uint8_t number = 0;
+    while (1)
+    {
+        for (number = 0; number < 5; number++)
+        {
+            result = xSemaphoreTake(static_sem, portMAX_DELAY);
+            if (result != pdPASS)
+            {
+                rt_kprintf("thread1 take a static semaphore, failed.\n");
+                return;
+            }
+            else
+            {
+                rt_kprintf("thread1 take a static semaphore. number = %d\n", number);
+            }
+        }
+        result = xSemaphoreTake(static_sem, 0);
+        if (result != errQUEUE_EMPTY)
+        {
+            rt_kprintf("thread1 take a static semaphore. number = %d. Should not succeed.\n", number);
+        }
+        rt_thread_delay(rt_tick_from_millisecond(10000));
+    }
+}
+
+ALIGN(RT_ALIGN_SIZE)
+static char thread2_stack[1024];
+static struct rt_thread thread2;
+static void rt_thread2_entry(void *parameter)
+{
+    static rt_err_t result;
+    static rt_uint8_t number = 0;
+    while (1)
+    {
+        for (number = 0; number < 5; number++)
+        {
+            result = xSemaphoreGive(static_sem);
+            if (result != pdPASS)
+            {
+                rt_kprintf("thread2 release a static semaphore, failed.\n");
+                return;
+            }
+            else
+            {
+                rt_kprintf("thread2 release a static semaphore. number = %d\n", number);
+            }
+        }
+        result = xSemaphoreGive(static_sem);
+        if (result != errQUEUE_FULL)
+        {
+            rt_kprintf("thread2 release a static semaphore. number = %d. Should not succeed.\n", number);
+        }
+        rt_thread_delay(rt_tick_from_millisecond(10000));
+    }
+}
+
+/* 信号量示例的初始化 */
+int semaphore_counting_static()
+{
+    /* 创建一个动态信号量，初始值是0 */
+    static_sem = xSemaphoreCreateCountingStatic(5, 0, &xMutexBuffer);
+    if (static_sem == RT_NULL)
+    {
+        rt_kprintf("create static semaphore failed.\n");
+        return -1;
+    }
+    rt_thread_init(&thread1,
+                   "thread1",
+                   rt_thread1_entry,
+                   RT_NULL,
+                   &thread1_stack[0],
+                   sizeof(thread1_stack),
+                   THREAD_PRIORITY, THREAD_TIMESLICE);
+    rt_thread_startup(&thread1);
+
+    rt_thread_init(&thread2,
+                   "thread2",
+                   rt_thread2_entry,
+                   RT_NULL,
+                   &thread2_stack[0],
+                   sizeof(thread2_stack),
+                   THREAD_PRIORITY - 1, THREAD_TIMESLICE);
+    rt_thread_startup(&thread2);
+
+    return 0;
+}
+
+/* 导出到 msh 命令列表中 */
+MSH_CMD_EXPORT(semaphore_counting_static, semaphore sample);


### PR DESCRIPTION
基本的信号量/互斥量动静态函数。
FreeRTOS有两种互斥量：Mutex和RecursiveMutex。RecursiveMutex可以由同一个线程重复获取，Mutex不行。RT-Thread的rt_mutex_t相当于RecursiveMutex。兼容层里两种互斥量都用rt_mutex_t实现，不做区分。
FreeRTOS信号量的值可以设定一个上限，到达上限后释放信号量，信号量值不再增加。这点和RT-Thread不同，RT-Thread信号量值最大可以到RT_SEM_VALUE_MAX。兼容层里把信号量最大值记录在rt_sem_t->reserved，并做相应处理。

